### PR TITLE
Hold onto replacement references

### DIFF
--- a/monkey.go
+++ b/monkey.go
@@ -11,13 +11,13 @@ import (
 // needed to undo a patch
 type patch struct {
 	originalBytes []byte
+	replacement   *reflect.Value
 }
 
 var (
 	lock = sync.Mutex{}
 
 	patches = make(map[reflect.Value]patch)
-	values  = make(map[reflect.Value]*reflect.Value)
 )
 
 type value struct {
@@ -85,8 +85,7 @@ func patchValue(target, replacement reflect.Value) {
 	}
 
 	bytes := replaceFunction(*(*uintptr)(getPtr(target)), uintptr(getPtr(replacement)))
-	patches[target] = patch{bytes}
-	values[target] = &replacement // To prevent GC from causing a crash
+	patches[target] = patch{bytes, &replacement}
 }
 
 // Unpatch removes any monkey patches on target

--- a/monkey.go
+++ b/monkey.go
@@ -17,6 +17,7 @@ var (
 	lock = sync.Mutex{}
 
 	patches = make(map[reflect.Value]patch)
+	values  = make(map[reflect.Value]*reflect.Value)
 )
 
 type value struct {
@@ -85,6 +86,7 @@ func patchValue(target, replacement reflect.Value) {
 
 	bytes := replaceFunction(*(*uintptr)(getPtr(target)), uintptr(getPtr(replacement)))
 	patches[target] = patch{bytes}
+	values[target] = &replacement // To prevent GC from causing a crash
 }
 
 // Unpatch removes any monkey patches on target


### PR DESCRIPTION
This is to prevent the garbage collector from freeing the replacement. Doing so appears to cause a crash when the patched function is called:

```
unexpected fault address 0xc82041c740
fatal error: fault
[signal 0xb code=0x2 addr=0xc82041c740 pc=0xc82041c740]

goroutine 4 [running]:
runtime.throw(0xa1b1c8, 0x5)
        /home/aluce/.gvm/gos/go1.6.2/src/runtime/panic.go:547 +0x90 fp=0xc820037d08 sp=0xc820037cf0
runtime.sigpanic()
        /home/aluce/.gvm/gos/go1.6.2/src/runtime/sigpanic_unix.go:27 +0x2ab fp=0xc820037d58 sp=0xc820037d08
github.com/lyfe-mobile/receiver.StartMovers.func1(0xc8204090e0, 0xc820409140, 0x1312d00, 0xa33b30, 0xa)
        /home/aluce/.gvm/pkgsets/go1.6.2/global/src/github.com/lyfe-mobile/receiver/movers.go:37 +0x531 fp=0xc820037f88 sp=0xc20037d58
```
