### PR TITLE
Fix problems with go1.7+

### DIFF
--- a/monkey_test.go
+++ b/monkey_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bouk/monkey"
+  "."
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,15 +84,36 @@ func TestWithInstanceMethod(t *testing.T) {
 
 type f struct{}
 
-func (f *f) no() bool { return false }
+func (f *f) No() bool { return false }
+func (f *f) Yes() bool { return true }
 
 func TestOnInstanceMethod(t *testing.T) {
 	i := &f{}
-	assert.False(t, i.no())
-	monkey.PatchInstanceMethod(reflect.TypeOf(i), "no", func(_ *f) bool { return true })
-	assert.True(t, i.no())
-	assert.True(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "no"))
-	assert.False(t, i.no())
+  
+	assert.True(t, i.Yes())
+	assert.False(t, i.No())
+	monkey.PatchInstanceMethod(reflect.TypeOf(i), "No", func(*f) bool { return true })
+	assert.True(t, i.Yes())
+	assert.True(t, i.No())
+	assert.True(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "No"))
+	assert.True(t, i.Yes())
+	assert.False(t, i.No())
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(i), "Yes", func(*f) bool { return false })
+	assert.False(t, i.Yes())
+	assert.False(t, i.No())
+	assert.True(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "Yes"))
+	assert.True(t, i.Yes())
+	assert.False(t, i.No())
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(i), "Yes", func(*f) bool { return false })
+	monkey.PatchInstanceMethod(reflect.TypeOf(i), "No", func(*f) bool { return true })
+	assert.False(t, i.Yes())
+	assert.True(t, i.No())
+	assert.True(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "Yes"))
+	assert.True(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "No"))
+	assert.True(t, i.Yes())
+	assert.False(t, i.No())
 }
 
 func TestNotFunction(t *testing.T) {

--- a/monkey_test.go
+++ b/monkey_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-  "."
+	"github.com/bouk/monkey"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
There were failures with go1.7 and higher in the TestOnInstanceMethod test.

First was:

    panic: unknown method no [recovered]
            panic: unknown method no

This appears to be due to https://github.com/golang/go/issues/15673 where unexported methods are made even harder to get to via reflection.

With that addressed, tests still failed:

    --- FAIL: TestOnInstanceMethod (0.00s)
            Error Trace:    monkey_test.go:94
            Error:          Should be true
            Error Trace:    monkey_test.go:95
            Error:          Should be false

This appears to be due to `reflect.Value` no longer being usable to uniquely identify a method. Using `.Pointer()` on the `reflect.Value` gives a workable ID.