### PR TITLE
add PatchInstanceMethodFlexible function

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ func main() {
 
 Note that patching the method for just one instance is currently not possible, `PatchInstanceMethod` will patch it for all instances. Don't bother trying `monkey.Patch(instance.Method, replacement)`, it won't work. `monkey.UnpatchInstanceMethod(<type>, <name>)` will undo `PatchInstanceMethod`.
 
+If you want to patch an instance method without support input parameters (useful when we interested only in return value or when we don't have access to the private receiver type) you can use  `PatchInstanceMethodFlexible`, for example previous example could be rewritten as:
+```go
+    monkey.PatchInstanceMethodFlexible(reflect.TypeOf(d), "Dial", func( /*NO INPUT PARAMETERS*/) (net.Conn, error) {
+        ...
+    })
+```
+or if we are interested in some input parameter
+```
+    monkey.PatchInstanceMethodFlexible(reflect.TypeOf(d), "Dial", func(_, _ interface{}, a string) (net.Conn, error) {
+        // can use "a"
+    })
+
+    same:
+
+    monkey.PatchInstanceMethodFlexible(reflect.TypeOf(d), "Dial", func(_, _, a interface{}) (net.Conn, error) {
+        // can use "a.(string)"
+    })
+```
+
 If you want to remove all currently applied monkeypatches simply call `monkey.UnpatchAll`. This could be useful in a test teardown function.
 
 If you want to call the original function from within the replacement you need to use a `monkey.PatchGuard`. A patchguard allows you to easily remove and restore the patch so you can call the original function. For example:

--- a/examples/instance_example.go
+++ b/examples/instance_example.go
@@ -21,7 +21,7 @@ func main() {
 // This will do same as done in main:
 func PatchInstanceMethodFlexibleExample1() {
 	var d *net.Dialer
-	monkey.PatchInstanceMethod(reflect.TypeOf(d), "Dial", func() (net.Conn, error) {
+	monkey.PatchInstanceMethodFlexible(reflect.TypeOf(d), "Dial", func() (net.Conn, error) {
 		return nil, fmt.Errorf("no dialing allowed")
 	})
 	_, err := http.Get("http://google.com")
@@ -31,7 +31,7 @@ func PatchInstanceMethodFlexibleExample1() {
 // Eliminate/use input variables example:
 func PatchInstanceMethodFlexibleExample2() {
 	var d *net.Dialer
-	monkey.PatchInstanceMethod(reflect.TypeOf(d), "Dial", func(_, _ interface{}, address string) (net.Conn, error) {
+	monkey.PatchInstanceMethodFlexible(reflect.TypeOf(d), "Dial", func(_, _ interface{}, address string) (net.Conn, error) {
 		return nil, fmt.Errorf("no dialing allowed for address: %s", address)
 	})
 	_, err := http.Get("http://google.com")

--- a/examples/instance_example.go
+++ b/examples/instance_example.go
@@ -17,3 +17,23 @@ func main() {
 	_, err := http.Get("http://google.com")
 	fmt.Println(err) // Get http://google.com: no dialing allowed
 }
+
+// This will do same as done in main:
+func PatchInstanceMethodFlexibleExample1() {
+	var d *net.Dialer
+	monkey.PatchInstanceMethod(reflect.TypeOf(d), "Dial", func() (net.Conn, error) {
+		return nil, fmt.Errorf("no dialing allowed")
+	})
+	_, err := http.Get("http://google.com")
+	fmt.Println(err) // Get http://google.com: no dialing allowed
+}
+
+// Eliminate/use input variables example:
+func PatchInstanceMethodFlexibleExample2() {
+	var d *net.Dialer
+	monkey.PatchInstanceMethod(reflect.TypeOf(d), "Dial", func(_, _ interface{}, address string) (net.Conn, error) {
+		return nil, fmt.Errorf("no dialing allowed for address: %s", address)
+	})
+	_, err := http.Get("http://google.com")
+	fmt.Println(err) // Get http://google.com: no dialing allowed
+}

--- a/monkey_test.go
+++ b/monkey_test.go
@@ -95,6 +95,33 @@ func TestOnInstanceMethod(t *testing.T) {
 	assert.False(t, i.no())
 }
 
+func TestOnInstanceMethodFlexibleWithInputParameters(t *testing.T) {
+	i := &f{}
+	assert.False(t, i.no())
+	monkey.PatchInstanceMethodFlexible(reflect.TypeOf(i), "no", func(_ interface{}) bool { return true })
+	assert.True(t, i.no())
+	assert.True(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "no"))
+	assert.False(t, i.no())
+}
+
+func TestOnInstanceMethodFlexibleWithoutInputParameters(t *testing.T) {
+	i := &f{}
+	assert.False(t, i.no())
+	monkey.PatchInstanceMethodFlexible(reflect.TypeOf(i), "no", func() bool { return true })
+	assert.True(t, i.no())
+	assert.True(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "no"))
+	assert.False(t, i.no())
+}
+
+func TestOnInstanceMethodFlexibleNotCompatibleTooManyParameters(t *testing.T) {
+	i := &f{}
+	assert.False(t, i.no())
+	assert.Panics(t, func() {
+		// replacement has to many arguments
+		monkey.PatchInstanceMethodFlexible(reflect.TypeOf(i), "no", func(_ interface{}, _ interface{}) bool { return true })
+	})
+}
+
 func TestNotFunction(t *testing.T) {
 	assert.Panics(t, func() {
 		monkey.Patch(no, 1)


### PR DESCRIPTION
Extension to `PatchInstanceMethod` functionality.

If we want to patch an instance method without support input parameters:
- must when we **don't have access to the private receiver type** 
- might be useful when we interested only in return value

Added `PatchInstanceMethodFlexible`, similar to `PatchInstanceMethod`, but doesn't require input parameters be the same type as patched method input parameters.  

For example could be used as:
```go
    monkey.PatchInstanceMethodFlexible(reflect.TypeOf(d), "Dial", func( /*NO INPUT PARAMETERS*/) (net.Conn, error) {
        ...
    })

    // or if we are interested in some input parameter
    monkey.PatchInstanceMethodFlexible(reflect.TypeOf(d), "Dial", func(_, _ interface{}, a string) (net.Conn, error) {
        // can use "a"
    })
```
In both examples above, the first input param in the replacement func is the "receiver". 
If it's private - widely used to expose "d" as interface and initiate it with "private" implementation - patch can't be done :/
`PatchInstanceMethodFlexible` allows us to define replacement func without specify real inputs type, so we can patch also functions with "private" receiver
