### PR TITLE
reflect.Value should not be used as map key

### DIFF
--- a/monkey_test.go
+++ b/monkey_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"../monkey"
+	"."
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,7 +51,6 @@ func TestGuard(t *testing.T) {
 	guard = monkey.Patch(no, func() bool {
 		guard.Unpatch()
 		defer guard.Restore()
-
 		return !no()
 	})
 	for i := 0; i < 100; i++ {

--- a/monkey_test.go
+++ b/monkey_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"../monkey"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,15 +84,15 @@ func TestWithInstanceMethod(t *testing.T) {
 
 type f struct{}
 
-func (f *f) no() bool { return false }
+func (f *f) No() bool { return false }
 
 func TestOnInstanceMethod(t *testing.T) {
 	i := &f{}
-	assert.False(t, i.no())
-	monkey.PatchInstanceMethod(reflect.TypeOf(i), "no", func(_ *f) bool { return true })
-	assert.True(t, i.no())
-	assert.True(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "no"))
-	assert.False(t, i.no())
+	assert.False(t, i.No())
+	monkey.PatchInstanceMethod(reflect.TypeOf(i), "No", func(_ *f) bool { return true })
+	assert.True(t, i.No())
+	assert.True(t, monkey.UnpatchInstanceMethod(reflect.TypeOf(i), "No"))
+	assert.False(t, i.No())
 }
 
 func TestNotFunction(t *testing.T) {


### PR DESCRIPTION
```go
type Value struct {
	typ *rtype
	ptr unsafe.Pointer
	flag
}
var v reflect.Value
```

`rtype.MethodByName()` returns a new Value object with a different ptr, so we should use its underlying value as map key instead. I suggest to use reflect.Pointer() to get that value and changed a bit of the testing code. @allenluce has done a great job, however there is still room for some improvement...(actually I want to be merged cuz I also fixed this issue independently😂)