### PR TITLE
segmentation violation when the function body lies near the end of a page

### DIFF
--- a/replace_unix.go
+++ b/replace_unix.go
@@ -6,10 +6,10 @@ import (
 	"syscall"
 )
 
-func mprotectCrossPage(addr uintptr, len int, prot int) {
+func mprotectCrossPage(addr uintptr, length int, prot int) {
 	pageSize := syscall.Getpagesize()
-	for p := pageStart(addr); p <= addr + uintptr(len); p += uintptr(pageSize) {
-		page := rawMemoryAccess(p, syscall.Getpagesize())
+	for p := pageStart(addr); p <= addr + uintptr(length); p += uintptr(pageSize) {
+		page := rawMemoryAccess(p, pageSize)
 		err := syscall.Mprotect(page, prot)
 		if err != nil {
 			panic(err)

--- a/replace_unix.go
+++ b/replace_unix.go
@@ -6,21 +6,24 @@ import (
 	"syscall"
 )
 
+func mprotectCrossPage(addr uintptr, len int, prot int) {
+	pageSize := syscall.Getpagesize()
+	for p := pageStart(addr); p <= addr + uintptr(len); p += uintptr(pageSize) {
+		page := rawMemoryAccess(p, syscall.Getpagesize())
+		err := syscall.Mprotect(page, prot)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
 // this function is super unsafe
 // aww yeah
 // It copies a slice to a raw memory location, disabling all memory protection before doing so.
 func copyToLocation(location uintptr, data []byte) {
 	f := rawMemoryAccess(location, len(data))
 
-	page := rawMemoryAccess(pageStart(location), syscall.Getpagesize())
-	err := syscall.Mprotect(page, syscall.PROT_READ|syscall.PROT_WRITE|syscall.PROT_EXEC)
-	if err != nil {
-		panic(err)
-	}
+	mprotectCrossPage(location, len(data), syscall.PROT_READ|syscall.PROT_WRITE|syscall.PROT_EXEC)
 	copy(f, data[:])
-
-	err = syscall.Mprotect(page, syscall.PROT_READ|syscall.PROT_EXEC)
-	if err != nil {
-		panic(err)
-	}
+	mprotectCrossPage(location, len(data), syscall.PROT_READ|syscall.PROT_EXEC)
 }

--- a/replace_unix.go
+++ b/replace_unix.go
@@ -8,7 +8,7 @@ import (
 
 func mprotectCrossPage(addr uintptr, length int, prot int) {
 	pageSize := syscall.Getpagesize()
-	for p := pageStart(addr); p <= addr + uintptr(length); p += uintptr(pageSize) {
+	for p := pageStart(addr); p < addr + uintptr(length); p += uintptr(pageSize) {
 		page := rawMemoryAccess(p, pageSize)
 		err := syscall.Mprotect(page, prot)
 		if err != nil {


### PR DESCRIPTION
I fixed it by calling Mprotect several times