### PR TITLE
Using jmp rdx

### DIFF
--- a/monkey.go
+++ b/monkey.go
@@ -1,4 +1,4 @@
-package monkey // import "bou.ke/monkey"
+package monkey //
 
 import (
 	"fmt"
@@ -84,7 +84,7 @@ func patchValue(target, replacement reflect.Value) {
 		unpatch(target.Pointer(), patch)
 	}
 
-	bytes := replaceFunction(target.Pointer(), (uintptr)(getPtr(replacement)))
+	bytes := replaceFunction(target.Pointer(), replacement.Pointer())
 	patches[target.Pointer()] = patch{bytes, &replacement}
 }
 

--- a/monkey.go
+++ b/monkey.go
@@ -1,4 +1,4 @@
-package monkey //
+package monkey // import "bou.ke/monkey"
 
 import (
 	"fmt"

--- a/monkey_amd64.go
+++ b/monkey_amd64.go
@@ -3,15 +3,15 @@ package monkey
 // Assembles a jump to a function value
 func jmpToFunctionValue(to uintptr) []byte {
 	return []byte{
-		0x48, 0xBA,
+		0x48, 0xC7, 0xC2,
 		byte(to),
 		byte(to >> 8),
 		byte(to >> 16),
 		byte(to >> 24),
-		byte(to >> 32),
-		byte(to >> 40),
-		byte(to >> 48),
-		byte(to >> 56), // movabs rdx,to
-		0xFF, 0x22,     // jmp QWORD PTR [rdx]
+		//byte(to >> 32),
+		//byte(to >> 40),
+		//byte(to >> 48),
+		//byte(to >> 56), // movabs rdx,to
+		0xFF, 0xE2,     // jmp QWORD PTR [rdx]
 	}
 }

--- a/monkey_amd64.go
+++ b/monkey_amd64.go
@@ -7,11 +7,7 @@ func jmpToFunctionValue(to uintptr) []byte {
 		byte(to),
 		byte(to >> 8),
 		byte(to >> 16),
-		byte(to >> 24),
-		//byte(to >> 32),
-		//byte(to >> 40),
-		//byte(to >> 48),
-		//byte(to >> 56), // movabs rdx,to
-		0xFF, 0xE2,     // jmp QWORD PTR [rdx]
+		byte(to >> 24), // MOV rdx, to
+		0xFF, 0xE2,     // JMP rdx
 	}
 }


### PR DESCRIPTION
Code optimization:
1.using reflect.ValueOf(fn).Pointer() to get target，replacement function address
2.using 'jmp rdx' instead of 'jmp [rdx]'