### PR TITLE
fix import for go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	"bou.ke/monkey"
+	"github.com/bouk/monkey"
 )
 
 func main() {
@@ -50,7 +50,7 @@ import (
 	"net/http"
 	"reflect"
 
-	"bou.ke/monkey"
+	"github.com/bouk/monkey"
 )
 
 func main() {
@@ -79,7 +79,7 @@ import (
 	"reflect"
 	"strings"
 
-	"bou.ke/monkey"
+	"github.com/bouk/monkey"
 )
 
 func main() {

--- a/examples/bleep.go
+++ b/examples/bleep.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"bou.ke/monkey"
+	"github.com/bouk/monkey"
 )
 
 func main() {

--- a/examples/instance_example.go
+++ b/examples/instance_example.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"reflect"
 
-	"bou.ke/monkey"
+	"github.com/bouk/monkey"
 )
 
 func main() {

--- a/examples/no_http.go
+++ b/examples/no_http.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"bou.ke/monkey"
+	"github.com/bouk/monkey"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module bou.ke/monkey
+module github.com/bouk/monkey
 
 go 1.13

--- a/monkey.go
+++ b/monkey.go
@@ -1,4 +1,4 @@
-package monkey // import "bou.ke/monkey"
+package monkey // import "github.com/bouk/monkey"
 
 import (
 	"fmt"

--- a/monkey_test.go
+++ b/monkey_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/bouk/monkey"
 )
 
 func no() bool  { return false }


### PR DESCRIPTION
Hi
This PR fix issue when trying to install this module using go mod.
```
 github.com/bouk/monkey: github.com/bouk/monkey@v1.0.2: parsing go.mod:
        module declares its path as: bou.ke/monkey
                but was required as: github.com/bouk/monkey
```